### PR TITLE
Async AMI events support

### DIFF
--- a/ami.go
+++ b/ami.go
@@ -229,15 +229,12 @@ func classifier(in chan M) (chanOutResponses chan M, chanOutEvents chan M) {
 		for {
 			data := <-in
 
-			for d := range data {
-				switch d {
-				case "Response":
-					chanOutResponses <- data
-					break
-				case "Event":
-					chanOutEvents <- data
-					break
-				}
+			if _, ok := data["Event"]; ok {
+				chanOutEvents <- data
+				continue
+			}
+			if _, ok := data["Response"]; ok {
+				chanOutResponses <- data
 			}
 		}
 	}()


### PR DESCRIPTION
I've just added support of Async AMI events. With Async mode we receive events with both "Event" and "Response" fields, so for now code blocks on sending data to channel that no one listen on the other side here: 
`chanOutResponses <- data`
