### PR TITLE
Changing "Time" field on events to avoid conflict

### DIFF
--- a/ami.go
+++ b/ami.go
@@ -393,7 +393,7 @@ func (a *amiAdapter) reader(conn net.Conn, stop <-chan struct{}, readErrChan cha
 			}
 
 			event["#"] = strconv.Itoa(i)
-			event["Time"] = time.Now().Format(time.RFC3339Nano)
+			event["TimeReceived"] = time.Now().Format(time.RFC3339Nano)
 			chanEvents <- event
 		}
 	}()


### PR DESCRIPTION
There are AMI events (e.g. PeerStatus) that already include a "Time" field. This was being overwritten by amigo with a timestamp from when the event was received. Simplest solution is to rename the field that amigo adds to the event.

Fixes #20 