### PR TITLE
add new fuction EventsChanLength to expose the length of eventsChan

### DIFF
--- a/amigo.go
+++ b/amigo.go
@@ -289,6 +289,11 @@ func (a *Amigo) UnregisterDefaultHandler(f handlerFunc) error {
 	return nil
 }
 
+// EventsChanLength returns the current size of eventsChan
+func (a *Amigo) EventsChanLength() int {
+	return len(a.ami.eventsChan)
+}
+
 // UnregisterHandler removes handler function for provided event name
 func (a *Amigo) UnregisterHandler(event string, f handlerFunc) error {
 	event = strings.ToUpper(event)


### PR DESCRIPTION
Hello. I'd like to add a new function to Amigo to expose the length of eventsChan. So that we can monitor it and know if our handler is processing events fast enough.
If `len(eventsChan)` is increasing, I think our handler is too slow to process the AMI events, we need some improvement.

