### PR TITLE
Fix go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/ivahaev/amigo
+
+go 1.13


### PR DESCRIPTION
When `ivahaev/amigo` is installed as master branch by `go get -u github.com/ivahaev/amigo@master`, but the installation will be failed.
(`ivahaev/amigo` will be installed as v0.1.10, that is newest version tag, instead of master branch)

```sh
$ go get -u github.com/ivahaev/amigo@master
go: github.com/ivahaev/amigo master => v0.1.10-0.20200221055615-ed43309fd42a 
```

This PR fixes the problem.